### PR TITLE
Locked down js-yaml dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash": "^2.4.1",
     "morgan": "~1.3.0",
     "serve-favicon": "^2.1.5",
-    "js-yaml": "^3.2.2",
+    "js-yaml": "~3.4.0",
     "swagger-server": "0.x"
   }
 }


### PR DESCRIPTION
js-yaml 3.5.x causes parsing errors